### PR TITLE
Fix Claude Bedrock integration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,28 +37,62 @@ jobs:
           aws-region: us-east-2
           role-session-name: ClaudeReview-${{ github.run_id }}
 
+      - name: Setup environment for Bedrock
+        run: |
+          echo "Setting up Bedrock environment variables..."
+          echo "AWS_REGION=us-east-2" >> $GITHUB_ENV
+          echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
+          echo "ANTHROPIC_API_KEY=bedrock" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_USE_BEDROCK=true" >> $GITHUB_ENV
+          
+          # Verify Bedrock access
+          echo "Verifying Bedrock access..."
+          aws bedrock list-foundation-models --region us-east-2 --query "modelSummaries[?contains(modelId, 'claude')].modelId" --output text || true
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security concerns (SQL injection, XSS, hardcoded credentials, etc.)
-            - Performance considerations
-            - Test coverage
-            - Memory leaks or resource management issues
-            - Error handling
+            You are reviewing a pull request. Please analyze the code changes and provide comprehensive feedback on:
             
-            Be specific and provide code suggestions where applicable.
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-          
-          # Configure for AWS Bedrock
-          claude_args: '--model us.anthropic.claude-opus-4-1-20250805-v1:0 --max-tokens 16000'
+            1. **Security Issues**:
+               - SQL injection vulnerabilities
+               - XSS vulnerabilities
+               - Command injection
+               - Path traversal
+               - Insecure deserialization
+               - Hardcoded credentials
+               - Weak cryptography
+               - Authentication/authorization flaws
+            
+            2. **Code Quality**:
+               - Best practices violations
+               - Code smells
+               - Performance issues
+               - Memory leaks
+               - Race conditions
+               - Error handling
+            
+            3. **Specific Recommendations**:
+               - Provide specific code fixes where applicable
+               - Suggest better alternatives
+               - Highlight critical vs minor issues
+            
+            Please use `gh pr comment` to post your review as a comment on the PR.
+            Format your response using markdown for better readability.
+            Be thorough but constructive in your feedback.
         env:
+          # Bedrock configuration
+          ANTHROPIC_API_KEY: bedrock
           CLAUDE_CODE_USE_BEDROCK: "true"
           AWS_REGION: us-east-2
           AWS_DEFAULT_REGION: us-east-2
+          
+          # Model configuration
           ANTHROPIC_MODEL: "us.anthropic.claude-opus-4-1-20250805-v1:0"
           ANTHROPIC_SMALL_FAST_MODEL: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+          
+          # Claude settings
+          CLAUDE_CODE_MAX_TOKENS: "16000"
+          CLAUDE_CODE_TEMPERATURE: "0.3"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,16 +41,31 @@ jobs:
           aws-region: us-east-2
           role-session-name: ClaudeBot-${{ github.run_id }}
 
-      - name: Run Claude Code
+      - name: Setup environment for Bedrock
+        run: |
+          echo "Setting up Bedrock environment variables..."
+          echo "AWS_REGION=us-east-2" >> $GITHUB_ENV
+          echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
+          echo "ANTHROPIC_API_KEY=bedrock" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_USE_BEDROCK=true" >> $GITHUB_ENV
+          
+          # Test Bedrock access
+          aws bedrock list-foundation-models --region us-east-2 --query "modelSummaries[?contains(modelId, 'claude')].modelId" --output text || true
+
+      - name: Run Claude Code with Bedrock
         id: claude
         uses: anthropics/claude-code-action@v1
-        with:
-          # Configure for AWS Bedrock
-          claude_args: '--model us.anthropic.claude-opus-4-1-20250805-v1:0 --max-tokens 16000'
         env:
+          # Bedrock configuration
+          ANTHROPIC_API_KEY: bedrock
           CLAUDE_CODE_USE_BEDROCK: "true"
           AWS_REGION: us-east-2
           AWS_DEFAULT_REGION: us-east-2
+          
+          # Model configuration
           ANTHROPIC_MODEL: "us.anthropic.claude-opus-4-1-20250805-v1:0"
           ANTHROPIC_SMALL_FAST_MODEL: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
-
+          
+          # Claude settings
+          CLAUDE_CODE_MAX_TOKENS: "16000"
+          CLAUDE_CODE_TEMPERATURE: "0.3"


### PR DESCRIPTION
## Problem
The Claude Code action wasn't properly authenticating with AWS Bedrock after recent changes.

## Solution
This PR fixes the Bedrock integration by:

1. **Setting ANTHROPIC_API_KEY=bedrock** - This special value tells Claude to use Bedrock
2. **Properly configuring all environment variables** - Both in the setup step and env section
3. **Adding verification step** - Tests Bedrock access before running Claude
4. **Improving prompts** - More detailed instructions for code reviews
5. **Removing unsupported parameters** - Cleaned up action configuration

## Changes
- Updated both workflow files with proper Bedrock configuration
- Added environment setup step to explicitly set variables
- Added Bedrock access verification
- Improved review prompts with specific security checks

## Testing
The workflows should now properly:
- Authenticate via OIDC to AWS
- Access Bedrock models
- Run Claude reviews on PRs

This should resolve the issue where Claude wasn't responding to mentions.