### PR TITLE
fix: Set Bedrock environment variables before Claude action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,6 +53,18 @@ jobs:
           echo "Testing Bedrock access..."
           aws bedrock list-inference-profiles --region us-east-2 --max-results 10 || true
 
+      - name: Setup Bedrock environment variables
+        run: |
+          echo "Setting up Bedrock environment variables..."
+          echo "ANTHROPIC_API_KEY=bedrock" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_USE_BEDROCK=true" >> $GITHUB_ENV
+          echo "AWS_REGION=us-east-2" >> $GITHUB_ENV
+          echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
+          echo "ANTHROPIC_MODEL=us.anthropic.claude-opus-4-1-20250805-v1:0" >> $GITHUB_ENV
+          echo "ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_MAX_TOKENS=16000" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_TEMPERATURE=0.3" >> $GITHUB_ENV
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -86,17 +98,3 @@ jobs:
             Please use `gh pr comment` to post your review as a comment on the PR.
             Format your response using markdown for better readability.
             Be thorough but constructive in your feedback.
-        env:
-          # Bedrock configuration
-          ANTHROPIC_API_KEY: bedrock
-          CLAUDE_CODE_USE_BEDROCK: "true"
-          AWS_REGION: us-east-2
-          AWS_DEFAULT_REGION: us-east-2
-          
-          # Model configuration
-          ANTHROPIC_MODEL: "us.anthropic.claude-opus-4-1-20250805-v1:0"
-          ANTHROPIC_SMALL_FAST_MODEL: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
-          
-          # Claude settings
-          CLAUDE_CODE_MAX_TOKENS: "16000"
-          CLAUDE_CODE_TEMPERATURE: "0.3"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,20 +57,18 @@ jobs:
           echo "Testing Bedrock access..."
           aws bedrock list-inference-profiles --region us-east-2 --max-results 10 || true
 
+      - name: Setup Bedrock environment variables
+        run: |
+          echo "Setting up Bedrock environment variables..."
+          echo "ANTHROPIC_API_KEY=bedrock" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_USE_BEDROCK=true" >> $GITHUB_ENV
+          echo "AWS_REGION=us-east-2" >> $GITHUB_ENV
+          echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
+          echo "ANTHROPIC_MODEL=us.anthropic.claude-opus-4-1-20250805-v1:0" >> $GITHUB_ENV
+          echo "ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_MAX_TOKENS=16000" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_TEMPERATURE=0.3" >> $GITHUB_ENV
+
       - name: Run Claude Code with Bedrock
         id: claude
         uses: anthropics/claude-code-action@v1
-        env:
-          # Bedrock configuration
-          ANTHROPIC_API_KEY: bedrock
-          CLAUDE_CODE_USE_BEDROCK: "true"
-          AWS_REGION: us-east-2
-          AWS_DEFAULT_REGION: us-east-2
-          
-          # Model configuration
-          ANTHROPIC_MODEL: "us.anthropic.claude-opus-4-1-20250805-v1:0"
-          ANTHROPIC_SMALL_FAST_MODEL: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
-          
-          # Claude settings
-          CLAUDE_CODE_MAX_TOKENS: "16000"
-          CLAUDE_CODE_TEMPERATURE: "0.3"


### PR DESCRIPTION
## Summary

This PR fixes the Bedrock authentication issue in Claude Code Action workflows by properly setting environment variables before the action initializes.

## Problem

The Claude Code Action was failing with:
```
Error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

This occurred because the action checks for environment variables during initialization, before the `env:` section of the action step is processed.

## Solution

Added a dedicated step to export all Bedrock-related environment variables to `$GITHUB_ENV` before the Claude Code Action runs:

1. **Setup Bedrock environment variables** step that exports:
   - `ANTHROPIC_API_KEY=bedrock` (triggers Bedrock mode)
   - `CLAUDE_CODE_USE_BEDROCK=true`
   - AWS region configuration
   - Model IDs
   - Token limits and temperature settings

2. Removed redundant `env:` sections from the action steps since variables are now in the GitHub environment

## Changes

- **`.github/workflows/claude.yml`**: Added environment setup step
- **`.github/workflows/claude-code-review.yml`**: Added environment setup step

## Testing

The environment variables are now available to the Claude Code Action during initialization, which should resolve the authentication error and allow the action to use AWS Bedrock via OIDC.

## Related Issues

- Previous PR #8 aligned workflows with test-oidc configuration
- This fixes the remaining issue where Claude action wasn't recognizing Bedrock mode