### PR TITLE
fix: Correct Bedrock environment variable configuration per documentation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,14 +56,13 @@ jobs:
       - name: Setup Bedrock environment variables
         run: |
           echo "Setting up Bedrock environment variables..."
-          echo "ANTHROPIC_API_KEY=bedrock" >> $GITHUB_ENV
-          echo "CLAUDE_CODE_USE_BEDROCK=true" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_USE_BEDROCK=1" >> $GITHUB_ENV
           echo "AWS_REGION=us-east-2" >> $GITHUB_ENV
           echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
           echo "ANTHROPIC_MODEL=us.anthropic.claude-opus-4-1-20250805-v1:0" >> $GITHUB_ENV
           echo "ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0" >> $GITHUB_ENV
-          echo "CLAUDE_CODE_MAX_TOKENS=16000" >> $GITHUB_ENV
-          echo "CLAUDE_CODE_TEMPERATURE=0.3" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_MAX_OUTPUT_TOKENS=16000" >> $GITHUB_ENV
+          echo "MAX_THINKING_TOKENS=1024" >> $GITHUB_ENV
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,14 +60,13 @@ jobs:
       - name: Setup Bedrock environment variables
         run: |
           echo "Setting up Bedrock environment variables..."
-          echo "ANTHROPIC_API_KEY=bedrock" >> $GITHUB_ENV
-          echo "CLAUDE_CODE_USE_BEDROCK=true" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_USE_BEDROCK=1" >> $GITHUB_ENV
           echo "AWS_REGION=us-east-2" >> $GITHUB_ENV
           echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
           echo "ANTHROPIC_MODEL=us.anthropic.claude-opus-4-1-20250805-v1:0" >> $GITHUB_ENV
           echo "ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0" >> $GITHUB_ENV
-          echo "CLAUDE_CODE_MAX_TOKENS=16000" >> $GITHUB_ENV
-          echo "CLAUDE_CODE_TEMPERATURE=0.3" >> $GITHUB_ENV
+          echo "CLAUDE_CODE_MAX_OUTPUT_TOKENS=16000" >> $GITHUB_ENV
+          echo "MAX_THINKING_TOKENS=1024" >> $GITHUB_ENV
 
       - name: Run Claude Code with Bedrock
         id: claude


### PR DESCRIPTION
## Summary

This PR corrects the Bedrock environment variable configuration based on the official AWS Bedrock documentation for Claude Code.

## Problem

The Claude Code Action was failing with:
```
Error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

This error occurred because we were using incorrect environment variable values that didn't properly trigger Bedrock mode.

## Root Cause

After reviewing the [official documentation](https://docs.anthropic.com/en/docs/claude-code/amazon-bedrock), the following issues were identified:

1. `CLAUDE_CODE_USE_BEDROCK` should be `1`, not `true`
2. `ANTHROPIC_API_KEY=bedrock` should not be set at all
3. `CLAUDE_CODE_MAX_TOKENS` should be `CLAUDE_CODE_MAX_OUTPUT_TOKENS`
4. Missing `MAX_THINKING_TOKENS` configuration

## Solution

Updated environment variable configuration according to documentation:

### Before (Incorrect):
```bash
ANTHROPIC_API_KEY=bedrock  # Wrong - shouldn't be set
CLAUDE_CODE_USE_BEDROCK=true  # Wrong value
CLAUDE_CODE_MAX_TOKENS=16000  # Wrong variable name
CLAUDE_CODE_TEMPERATURE=0.3  # Not in docs
```

### After (Correct):
```bash
CLAUDE_CODE_USE_BEDROCK=1  # Correct value to enable Bedrock
# No ANTHROPIC_API_KEY - uses AWS credentials instead
CLAUDE_CODE_MAX_OUTPUT_TOKENS=16000  # Correct variable name
MAX_THINKING_TOKENS=1024  # Added per documentation
```

## Changes

- Updated `.github/workflows/claude.yml`
- Updated `.github/workflows/claude-code-review.yml`

## Testing

With these corrections, the Claude Code Action should:
1. Recognize that it should use Bedrock mode (`CLAUDE_CODE_USE_BEDROCK=1`)
2. Use AWS credentials from OIDC authentication instead of looking for an API key
3. Properly configure token limits with the correct variable names

## References

- [Claude Code AWS Bedrock Documentation](https://docs.anthropic.com/en/docs/claude-code/amazon-bedrock)
- Previous error in PR #11: [Action Run](https://github.com/nogueiraanderson/pmm-bedrock-oidc-test/actions/runs/17294965751/job/49090813448?pr=11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized AI code-review workflow configuration for improved reliability.
  * Increased output limits and adjusted reasoning budget to enhance review quality.
  * Cleaned up redundant settings and aligned flags for consistent behavior across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->